### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -549,6 +549,9 @@
         if: failure() && (github.event_name == 'workflow_dispatch' ||
           contains(github.event.head_commit.message, '[rollback]'))
         environment: ${{ needs.prepare.outputs.deploy-environment || 'production' }}
+        permissions:
+          contents: read
+          issues: write
         steps:
           - name: Checkout repository
             uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ursisterbtw/ccprompts/security/code-scanning/19](https://github.com/ursisterbtw/ccprompts/security/code-scanning/19)

To resolve the issue, the explicit `permissions` block should be added to the `rollback` job in `.github/workflows/deploy.yml`. The permissions should be minimal and aligned with the job's needs. For the `rollback` job:
- It requires `contents: read` to access repository files during the rollback operations.
- No explicit `write` permissions are required unless the rollback process or notifications involve creating/modifying repository objects (e.g., issues). If notifications require `issues: write`, this should be included.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add permissions block to the rollback job in .github/workflows/deploy.yml granting contents: read and issues: write