### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -456,6 +456,8 @@
       post-deployment:
         name: Post-Deployment Tasks
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
         needs:
           - prepare
           - deploy-staging


### PR DESCRIPTION
Potential fix for [https://github.com/ursisterbtw/ccprompts/security/code-scanning/18](https://github.com/ursisterbtw/ccprompts/security/code-scanning/18)

To fix the problem, we need to add an explicit `permissions` block to the `Post-Deployment Tasks` job. This block should grant only the minimal privileges necessary for the job to complete its tasks. Based on the workflow steps, the job appears to require `contents: read` to access the repository and possibly no additional write permissions. This ensures the job adheres to the principle of least privilege, reducing potential security risks.

The fix involves adding the following `permissions` block to the `Post-Deployment Tasks` job:
```yaml
permissions:
  contents: read
```

This block explicitly limits the job's permissions to read-only access for repository contents, which is sufficient for actions like checking out the repository and reading files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add explicit contents: read permission to the Post-Deployment Tasks job in the GitHub Actions workflow